### PR TITLE
Feat/make controller: LectureController 구현 및 쿼리 오류 수정

### DIFF
--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetAppliedLecturesService.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetAppliedLecturesService.java
@@ -20,6 +20,7 @@ public class GetAppliedLecturesService {
   private final LectureQueryRepository lectureQueryRepository;
 
   @Data
+  @AllArgsConstructor
   public static class Input {
     private Long userId;
   }

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetLectureItemsService.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetLectureItemsService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class GetLectureItemsService {
   private final LectureQueryRepository lectureQueryRepository;
   @Data
+  @AllArgsConstructor
   public static class Input{
     private LocalDate date;
   }

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/infrastructure/repository/LectureQueryRepository.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/infrastructure/repository/LectureQueryRepository.java
@@ -44,8 +44,8 @@ public class LectureQueryRepository {
             lectureInventory.amount
         ))
         .from(lecture)
-        .join(lectureItem).on(lecture.id.eq(lectureItem.id))
-        .join(lectureInventory).on(lectureItem.id.eq(lectureInventory.id))
+        .join(lectureItem).on(lecture.id.eq(lectureItem.lecture_id))
+        .join(lectureInventory).on(lectureItem.id.eq(lectureInventory.item_id))
         .where(lectureItem.date.eq(date))
         .fetch();
   }
@@ -71,10 +71,10 @@ public class LectureQueryRepository {
             lectureInventory.amount
         ))
         .from(lecture)
-        .join(lectureItem).on(lecture.id.eq(lectureItem.id))
-        .join(lectureInventory).on(lectureItem.id.eq(lectureInventory.id))
-        .join(lectureHistory).on(lectureItem.id.eq(lectureHistory.id))
-        .where(lectureHistory.id.eq(userId))
+        .join(lectureItem).on(lecture.id.eq(lectureItem.lecture_id))
+        .join(lectureInventory).on(lectureItem.id.eq(lectureInventory.item_id))
+        .join(lectureHistory).on(lectureItem.id.eq(lectureHistory.item_id))
+        .where(lectureHistory.user_id.eq(userId))
         .fetch();
   }
 

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/ApiResponse.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/ApiResponse.java
@@ -1,0 +1,44 @@
+package com.sparta.hhplusw02cleanarchitecture.interfaces;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+  private int code;
+  private HttpStatus status;
+  private String message;
+  private T data;
+
+  public ApiResponse() {
+
+  }
+
+  public ApiResponse(HttpStatus status, String message, T data) {
+    this.code = status.value();
+    this.status = status;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
+    return new ApiResponse<>(status, message, data);
+  }
+
+  public static <T> ApiResponse<T> ok(T data) {
+    return of(OK, "SUCCESS", data);
+  }
+
+  public static <T> ApiResponse<T> created(T data) {
+    return of(CREATED, "CREATED", data);
+  }
+
+  public static <T> ApiResponse<T> found(T data) {
+    return of(FOUND, "FOUND", data);
+  }
+}

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureController.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureController.java
@@ -1,13 +1,23 @@
 package com.sparta.hhplusw02cleanarchitecture.interfaces.api;
 
+import com.sparta.hhplusw02cleanarchitecture.domain.lecture.usecase.ApplyLectureService;
+import com.sparta.hhplusw02cleanarchitecture.domain.lecture.usecase.GetAppliedLecturesService;
+import com.sparta.hhplusw02cleanarchitecture.domain.lecture.usecase.GetLectureItemsService;
+import com.sparta.hhplusw02cleanarchitecture.interfaces.ApiResponse;
 import com.sparta.hhplusw02cleanarchitecture.interfaces.request.ApplyLectureRequest;
+import com.sparta.hhplusw02cleanarchitecture.interfaces.response.GetLectureListResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -25,7 +35,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/lecture")
 public class LectureController {
 
-//  private final LectureFacade lectureFacade;
+  private final ApplyLectureService applyLectureService;
+  private final GetLectureItemsService getLectureItemsService;
+  private final GetAppliedLecturesService getAppliedLecturesService;
+
   /**
    * 특강 신청 API
    * - 특정 userId 로 선착순으로 제공되는 특강을 신청하는 API 를 작성합니다.
@@ -33,12 +46,20 @@ public class LectureController {
    * - 특강은 선착순 30명만 신청 가능합니다.
    * - 이미 신청자가 30명이 초과되면 이후 신청자는 요청을 실패합니다.
    */
-  @PostMapping("/{id}/apply")
-  public void applyLecture (
-      @PathVariable long id,
+  @PostMapping("/{userId}/apply")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ApiResponse<Long> applyLecture (
+      @PathVariable Long userId,
       @RequestBody ApplyLectureRequest request
   ){
-    return ;
+    log.debug("LectureController#applyLecture called.");
+    log.debug("userId={}", userId);
+    log.debug("ApplyLectureRequest={}", request);
+
+    Long savedHistoryId = applyLectureService.applyLecture(request.toInputDTO()).getHistoryId();
+
+    log.debug("savedHistoryId={}", savedHistoryId);
+    return ApiResponse.created(savedHistoryId);
   }
 
   /**
@@ -47,8 +68,20 @@ public class LectureController {
    * - 특강의 정원은 30명으로 고정이며, 사용자는 각 특강에 신청하기전 목록을 조회해볼 수 있어야 합니다.
    */
   @GetMapping("/lectures")
-  public void getLectures (){
-    return ;
+  public ApiResponse<List<GetLectureListResponse>> getLectures (@PathVariable LocalDate date){
+    log.debug("LectureController#getLectures called.");
+    log.debug("date={}", date);
+
+    GetLectureItemsService.Output output = getLectureItemsService.getLectures(
+        new GetLectureItemsService.Input(date)
+    );
+
+    List<GetLectureListResponse> responseList = output.getList().stream()
+        .map(lectureInfo -> new GetLectureListResponse(lectureInfo))
+        .collect(Collectors.toList());
+    log.debug("responseList={}", responseList);
+
+    return ApiResponse.ok(responseList);
   }
 
 
@@ -59,7 +92,20 @@ public class LectureController {
    * @param userId 조회할 유저 ID
    */
   @GetMapping("/{id}")
-  public void getCompletedLectures (Long userId){
-    return ;
+  public ApiResponse<List<GetLectureListResponse>> getCompletedLectures (@PathVariable Long userId){
+    log.debug("LectureController#getCompletedLectures called.");
+    log.debug("userId={}", userId);
+
+    GetAppliedLecturesService.Output output = getAppliedLecturesService.getAppliedLectures(
+        new GetAppliedLecturesService.Input(userId)
+    );
+
+    List<GetLectureListResponse> responseList = output.getList().stream()
+        .map(lectureInfo -> new GetLectureListResponse(lectureInfo))
+        .collect(Collectors.toList());
+
+    log.debug("responseList={}", responseList);
+
+    return ApiResponse.ok(responseList);
   }
 }

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureController.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -68,7 +69,7 @@ public class LectureController {
    * - 특강의 정원은 30명으로 고정이며, 사용자는 각 특강에 신청하기전 목록을 조회해볼 수 있어야 합니다.
    */
   @GetMapping("/lectures")
-  public ApiResponse<List<GetLectureListResponse>> getLectures (@PathVariable LocalDate date){
+  public ApiResponse<List<GetLectureListResponse>> getLectures (@RequestParam LocalDate date){
     log.debug("LectureController#getLectures called.");
     log.debug("date={}", date);
 
@@ -91,7 +92,7 @@ public class LectureController {
    * - 각 항목은 특강 ID 및 이름, 강연자 정보를 담고 있어야 합니다.
    * @param userId 조회할 유저 ID
    */
-  @GetMapping("/{id}")
+  @GetMapping("/{userId}")
   public ApiResponse<List<GetLectureListResponse>> getCompletedLectures (@PathVariable Long userId){
     log.debug("LectureController#getCompletedLectures called.");
     log.debug("userId={}", userId);

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/request/ApplyLectureRequest.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/request/ApplyLectureRequest.java
@@ -1,5 +1,7 @@
 package com.sparta.hhplusw02cleanarchitecture.interfaces.request;
 
+import com.sparta.hhplusw02cleanarchitecture.domain.lecture.usecase.ApplyLectureService;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,4 +14,25 @@ public class ApplyLectureRequest {
   private Long userId;
   private Long lectureId;
   private Long itemId;
+  private Long inventoryId;
+
+
+  @Builder
+  public ApplyLectureRequest(Long userId, Long lectureId, Long itemId, Long inventoryId) {
+    this.userId = userId;
+    this.lectureId = lectureId;
+    this.itemId = itemId;
+    this.inventoryId = inventoryId;
+  }
+
+
+  public ApplyLectureService.Input toInputDTO() {
+    return ApplyLectureService.Input.builder()
+        .userId(this.userId)
+        .lectureId(this.lectureId)
+        .itemId(this.itemId)
+        .inventoryId(this.inventoryId)
+        .build();
+  }
+
 }

--- a/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/response/GetLectureListResponse.java
+++ b/src/main/java/com/sparta/hhplusw02cleanarchitecture/interfaces/response/GetLectureListResponse.java
@@ -1,6 +1,8 @@
 package com.sparta.hhplusw02cleanarchitecture.interfaces.response;
 
+import com.sparta.hhplusw02cleanarchitecture.domain.lecture.LectureInfo;
 import java.time.LocalDate;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,10 +13,34 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class GetLectureListResponse {
+  private Long lectureId;
+  private Long itemId;
   private String title;
   private String instructor;
   private LocalDate date;
-  private Long capacity;
-  private Long amount;
+  private Integer capacity;
+  private Integer amount;
+
+  @Builder
+  public GetLectureListResponse(Long lectureId, Long itemId, String title, String instructor,
+      LocalDate date, Integer capacity, Integer amount) {
+    this.lectureId = lectureId;
+    this.itemId = itemId;
+    this.title = title;
+    this.instructor = instructor;
+    this.date = date;
+    this.capacity = capacity;
+    this.amount = amount;
+  }
+
+  public GetLectureListResponse(LectureInfo lectureInfo) {
+    this.lectureId = lectureInfo.lectureId();
+    this.itemId = lectureInfo.itemId();
+    this.title = lectureInfo.title();
+    this.instructor = lectureInfo.instructor();
+    this.date = lectureInfo.date();
+    this.capacity = lectureInfo.capacity();
+    this.amount = lectureInfo.amount();
+  }
 }
 

--- a/src/test/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetAppliedLecturesServiceTest.java
+++ b/src/test/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetAppliedLecturesServiceTest.java
@@ -41,8 +41,7 @@ class GetAppliedLecturesServiceTest {
     );
     when(lectureQueryRepository.findLectureInfosByUserId(userId)).thenReturn(lectureInfos);
 
-    GetAppliedLecturesService.Input input = new GetAppliedLecturesService.Input();
-    input.setUserId(userId);
+    GetAppliedLecturesService.Input input = new GetAppliedLecturesService.Input(userId);
 
     // When
     GetAppliedLecturesService.Output output = getAppliedLecturesService.getAppliedLectures(input);

--- a/src/test/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetLectureItemsServiceTest.java
+++ b/src/test/java/com/sparta/hhplusw02cleanarchitecture/domain/lecture/usecase/GetLectureItemsServiceTest.java
@@ -38,8 +38,7 @@ class GetLectureItemsServiceTest {
         );
     when(lectureQueryRepository.findLectureInfosByDate(date)).thenReturn(lectureInfos);
 
-    GetLectureItemsService.Input input = new GetLectureItemsService.Input();
-    input.setDate(date);
+    GetLectureItemsService.Input input = new GetLectureItemsService.Input(date);
 
     // When
     GetLectureItemsService.Output output = getLectureItemsService.getLectures(input);

--- a/src/test/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureControllerIntegrationTest.java
+++ b/src/test/java/com/sparta/hhplusw02cleanarchitecture/interfaces/api/LectureControllerIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.sparta.hhplusw02cleanarchitecture.interfaces.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.sparta.hhplusw02cleanarchitecture.interfaces.ApiResponse;
+import com.sparta.hhplusw02cleanarchitecture.interfaces.request.ApplyLectureRequest;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LectureControllerIntegrationTest {
+
+  /**
+   * 테스트 실행 전 실행되는 쿼리 INSERT INTO LECTURE (LECTURE_ID, TITLE, INSTRUCTOR) VALUES (1, '과제발제', '허재')
+   * INSERT INTO LECTURE (LECTURE_ID, TITLE, INSTRUCTOR) VALUES (2, '멘토링', '로이') INSERT INTO
+   * LECTURE_ITEM (ITEM_ID, LECTURE_ID, DATE, CAPACITY) VALUES (1, 1, '2024-09-28', 30) INSERT INTO
+   * LECTURE_ITEM (ITEM_ID, LECTURE_ID, DATE, CAPACITY) VALUES (2, 1, '2024-10-02', 30) INSERT INTO
+   * LECTURE_ITEM (ITEM_ID, LECTURE_ID, DATE, CAPACITY) VALUES (3, 2, '2024-10-02', 30) INSERT INTO
+   * LECTURE_ITEM (ITEM_ID, LECTURE_ID, DATE, CAPACITY) VALUES (4, 2, '2024-10-03', 30) INSERT INTO
+   * LECTURE_ITEM (ITEM_ID, LECTURE_ID, DATE, CAPACITY) VALUES (5, 2, '2024-10-04', 30) INSERT INTO
+   * LECTURE_INVENTORY (INVENTORY_ID, ITEM_ID, LECTURE_ID, AMOUNT) VALUES (1, 1, 1, 30) INSERT INTO
+   * LECTURE_INVENTORY (INVENTORY_ID, ITEM_ID, LECTURE_ID, AMOUNT) VALUES (2, 2, 1, 30) INSERT INTO
+   * LECTURE_INVENTORY (INVENTORY_ID, ITEM_ID, LECTURE_ID, AMOUNT) VALUES (3, 3, 2, 30) INSERT INTO
+   * LECTURE_INVENTORY (INVENTORY_ID, ITEM_ID, LECTURE_ID, AMOUNT) VALUES (4, 4, 2, 30) INSERT INTO
+   * LECTURE_INVENTORY (INVENTORY_ID, ITEM_ID, LECTURE_ID, AMOUNT) VALUES (5, 5, 2, 30)
+   */
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Test
+  @DisplayName("특강 하나를 신청한다.")
+  public void testApplyLecture() throws Exception {
+    //given
+    Long userId = 1L;
+    ApplyLectureRequest request = ApplyLectureRequest.builder()
+        .userId(userId)
+        .lectureId(1L)
+        .itemId(1L)
+        .inventoryId(1L)
+        .build();
+
+    // when
+    ResponseEntity<ApiResponse> response = restTemplate.postForEntity(
+        "/lecture/" + userId + "/apply",
+        request,
+        ApiResponse.class
+    );
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED); // 응답이 CREATED인지 확인
+    assertThat(response.getBody().getData()).isNotNull();               // 응답데이터가 null이 아닌지 확인
+//    assertThat(response.getBody().getData()).isEqualTo(2);     // 응답데이터가 제대로 들어왔는지 확인
+  }
+
+  @Test
+  @DisplayName("툭정 날짜의 특강 목록을 조회한다.")
+  public void testGetLectures() throws Exception {
+    //given
+    LocalDate date = LocalDate.of(2024, 10, 2);
+
+    //when
+    ResponseEntity<ApiResponse> response = restTemplate.getForEntity(
+        "/lecture/lectures?date=" + date.toString(),
+        ApiResponse.class
+    );
+
+    //then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK); //응답이 OK인지 확인
+    assertThat(response.getBody()).isNotNull();                    //응답 데이터가 null이 아닌지 확인
+    assertThat((List<?>) response.getBody().getData())
+        .hasSize(2);                                      //응답 데이터 사이즈가 2인지 확인
+  }
+
+  @Test
+  @DisplayName("특정 userId로 등록한 특강 목록을 조회한다.")
+  public void testGetCompletedLectures() throws Exception {
+    //given: 특강 신청
+    Long userId = 3L;
+    ApplyLectureRequest request = ApplyLectureRequest.builder()
+        .userId(userId)
+        .lectureId(1L)
+        .itemId(1L)
+        .inventoryId(1L)
+        .build();
+
+    restTemplate.postForEntity(
+        "/lecture/" + userId + "/apply",
+        request,
+        ApiResponse.class
+    );
+
+    //when
+    ResponseEntity<ApiResponse> response = restTemplate.getForEntity(
+        "/lecture/" + userId.toString(),
+        ApiResponse.class
+    );
+
+    //then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK); //응답이 OK인지 확인
+    assertThat(response.getBody()).isNotNull();                    //응답 데이터가 null이 아닌지 확인
+    assertThat((List<?>) response.getBody().getData())
+        .hasSize(1);                                      //응답 데이터 사이즈가 1인지 확인
+  }
+}


### PR DESCRIPTION
## 작업 내역
- LectureController.java 커스텀 ApiResponse 사용하여 구현함.
- LectureController.java에 대한 통합테스트 작성(해피케이스)

- `LectureQueryRepository.findLectureInfosByDate()` 와 `LectureQueryRepository.LectureQueryRepository()`의 잘못 된 조인 키 수정함

